### PR TITLE
Changed function for storing a data in APCu

### DIFF
--- a/src/Storage/ApcuCacheStorageAdapter.php
+++ b/src/Storage/ApcuCacheStorageAdapter.php
@@ -60,7 +60,7 @@ class ApcuCacheStorageAdapter implements StorageAdapterInterface
      */
     public function save($key, $value)
     {
-        $result = apcu_add($this->keyPrefix . $key, $value, $this->ttl);
+        $result = apcu_store($this->keyPrefix . $key, $value, $this->ttl);
         if ($result === false) {
             throw new StorageException("Can not save data to APCu Cache. Key: $key");
         }


### PR DESCRIPTION
According to this documentation http://php.net/manual/en/function.apcu-add.php it will return false when it fails to save a data. But it also means a case when the key already exists in APCu and the data will not be overwritten. So better will be to use this method http://php.net/manual/en/function.apcu-store.php. This method overwrites data when the key exists, so false is returned only in case of real error.